### PR TITLE
SREP-905 Added Makefile to be used from ci-operator prow job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+BINFILE=build/_output/bin/dedicated-admin-operator
+MAINPACKAGE=./cmd/manager
+GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+GOFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
+
+.PHONY: check
+check: ## Lint code
+	gofmt -s -l $(shell go list -f '{{ .Dir }}' ./... ) | grep ".*\.go"; if [ "$$?" = "0" ]; then gofmt -s -d $(shell go list -f '{{ .Dir }}' ./... ); exit 1; fi
+	go vet ./cmd/... ./pkg/...
+
+.PHONY: build
+build: ## Build binary
+	${GOENV} go build ${GOFLAGS} -o ${BINFILE} ${MAINPACKAGE}


### PR DESCRIPTION
Adding this Makefile that replicates exactly the gcflags and env variables used by operator-sdk build.

The prow ci job will call `make build`, since calling operator-sdk is not an option.

Also added a `make check` for linting.

