### PR TITLE
Change Dockerfile to a dual-staged build/run approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,8 @@ The Dedicated Admin Operator exposes the following Prometheus metrics:
 
 * dedicated_admin_blacklisted: gauge of blacklisted namespaces
 
-
+## Buid Notes
+The Dockerfile provided (in `build/Dockerfile`) takes advantage of the multi-stage feature, so docker version >= 17.05 is required. To build it locally please use:
+```
+docker build -f build/Dockerfile . -t openshift/dedicated-admin-operator:latest
+``` 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,19 @@
+FROM openshift/origin-release:golang-1.10 AS build
+ENV OPERATOR_PATH=/go/src/github.com/openshift/dedicated-admin-operator
+COPY . ${OPERATOR_PATH}
+WORKDIR ${OPERATOR_PATH}
+RUN yum update -y --exclude=golang && yum clean all && make build
+
 FROM alpine:3.8
+ENV OPERATOR_PATH=/go/src/github.com/openshift/dedicated-admin-operator \
+    OPERATOR_BIN=dedicated-admin-operator \
+    USER_UID=1001 \
+    USER_NAME=dedicated-admin-operator
 
-RUN apk upgrade --update --no-cache
-
-USER nobody
-
-ADD build/_output/bin/dedicated-admin-operator /usr/local/bin/dedicated-admin-operator
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=build ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
+USER ${USER_UID}
+LABEL io.openshift.managed.name="dedicated-admin-operator" \
+      io.openshift.managed.description="Operator to manage permissions for Dedicated admins"
+      


### PR DESCRIPTION
Pushing this Dockerfile to integrate with quay.io pipeline, and to test again ci-operator integration