### PR TITLE
SREP-1037 Created a separate Dockerfile for ci-operator

### DIFF
--- a/build/Dockerfile.ci-operator
+++ b/build/Dockerfile.ci-operator
@@ -1,0 +1,19 @@
+FROM openshift/origin-release:golang-1.10 AS build
+ENV OPERATOR_PATH=/go/src/github.com/openshift/dedicated-admin-operator
+COPY . ${OPERATOR_PATH}
+WORKDIR ${OPERATOR_PATH}
+RUN yum update -y --exclude=golang && yum clean all && make build
+
+FROM openshift/origin-release:golang-1.10
+ENV OPERATOR_PATH=/go/src/github.com/openshift/dedicated-admin-operator \
+    OPERATOR_BIN=dedicated-admin-operator \
+    USER_UID=1001 \
+    USER_NAME=dedicated-admin-operator
+
+RUN yum install ca-certificates && yum clean all
+WORKDIR /root/
+COPY --from=build ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
+USER ${USER_UID}
+LABEL io.openshift.managed.name="dedicated-admin-operator" \
+      io.openshift.managed.description="Operator to manage permissions for Dedicated admins"
+      


### PR DESCRIPTION
Since ci-operator replaces the FROM clauses on the Dockerfile to what is configured as the base image (a rhel based image), we can't have an alpine as the 2nd FROM, and can't use apk.

While I'm doing research, I'm creating this separate Dockerfile that will be configured for ci-operator, without impacting the working Dockerfile (build/Dockerfile working on quay.io)

