### PR TITLE
SREP-1037 Remove permission related clauses from Dockerfile for ci-oper

### DIFF
--- a/build/Dockerfile.ci-operator
+++ b/build/Dockerfile.ci-operator
@@ -6,14 +6,11 @@ RUN yum update -y --exclude=golang && yum clean all && make build
 
 FROM openshift/origin-release:golang-1.10
 ENV OPERATOR_PATH=/go/src/github.com/openshift/dedicated-admin-operator \
-    OPERATOR_BIN=dedicated-admin-operator \
-    USER_UID=1001 \
-    USER_NAME=dedicated-admin-operator
+    OPERATOR_BIN=dedicated-admin-operator
 
 RUN yum install ca-certificates && yum clean all
 WORKDIR /root/
 COPY --from=build ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
-USER ${USER_UID}
 LABEL io.openshift.managed.name="dedicated-admin-operator" \
       io.openshift.managed.description="Operator to manage permissions for Dedicated admins"
       


### PR DESCRIPTION
The ci-operator workflow forbids setting permissions/UIDs on the Dockerfile, removing it. 