### PR TITLE
dedicated-project-admin can list the namespace

### DIFF
--- a/manifests/03-dedicated-project-admin.ClusterRole.yaml
+++ b/manifests/03-dedicated-project-admin.ClusterRole.yaml
@@ -63,6 +63,7 @@ rules:
   attributeRestrictions: null
   resources:
   - events
+  - namespaces
   - pods
   verbs:
   - get


### PR DESCRIPTION
Was testing some authn/z and found dedicated-admin could not list projects, so couldn't see projects other users in the cluster could create.