### PR TITLE
isclean make target is quiet unless it fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ clean:
 
 .PHONY: isclean 
 isclean:
-	(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." && exit 1)
+	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." && exit 1)
 
 .PHONY: build
-build: isclean
+build: isclean envtest
 	docker build . -f build/ci-operator/Dockerfile -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):v$(VERSION_FULL)
 
 .PHONY: push
@@ -73,6 +73,14 @@ gobuild: gocheck gotest ## Build binary
 .PHONY: gotest
 gotest:
 	go test $(TESTOPTS) $(TESTTARGETS)
+
+.PHONY: envtest
+envtest:
+	@# test that the env target can be evaluated, required by osd-operators-registry
+	@eval $$($(MAKE) env --no-print-directory) || (echo 'Unable to evaulate output of `make env`.  This breaks osd-operators-registry.' && exit 1)
+
+.PHONY: test
+test: envtest gotest
 
 .PHONY: env
 env: isclean


### PR DESCRIPTION
The target is now quiet and added a test `envtest` to verify it works.  It is called from ci-operator build.  If this fails, we cannot generate the osd-operators registry.