### PR TITLE
Small fixes and additional namespaces blacklisted.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
 OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
 
 OPERATOR_IMAGE_URI=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):v$(OPERATOR_VERSION)
+OPERATOR_IMAGE_URI_LATEST=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):latest
 
 BINFILE=build/_output/bin/$(OPERATOR_NAME)
 MAINPACKAGE=./cmd/manager
@@ -57,10 +58,12 @@ isclean:
 .PHONY: build
 build: isclean envtest
 	docker build . -f build/ci-operator/Dockerfile -t $(OPERATOR_IMAGE_URI)
+	docker tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
 
 .PHONY: push
-push: build
+push:
 	docker push $(OPERATOR_IMAGE_URI)
+	docker push $(OPERATOR_IMAGE_URI_LATEST)
 
 .PHONY: gocheck
 gocheck: ## Lint code

--- a/manifests/10-dedicated-admin-operator.Deployment.yaml
+++ b/manifests/10-dedicated-admin-operator.Deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: dedicated-admin-operator
       containers:
         - name: dedicated-admin-operator
-          image: quay.io/redhat/dedicated-admin-operator:latest
+          image: quay.io/openshift-sre/dedicated-admin-operator:latest
           ports:
           - containerPort: 60000
             name: metrics

--- a/manifests/10-dedicated-admin-operator.Role.yaml
+++ b/manifests/10-dedicated-admin-operator.Role.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: dedicated-admin-operator
+  namespace: openshift-dedicated-admin
 rules:
 - apiGroups:
   - monitoring.coreos.com

--- a/pkg/dedicatedadmin/dedicatedadmin.go
+++ b/pkg/dedicatedadmin/dedicatedadmin.go
@@ -50,7 +50,7 @@ func GetOperatorConfig(ctx context.Context, k8sClient client.Client) (*corev1.Co
 			Namespace: operatorconfig.OperatorNamespace,
 		},
 		Data: map[string]string{
-			"project_blacklist": "^kube-.*,^openshift-.*,^logging$,^default$,^openshift$",
+			"project_blacklist": "^kube-.*,^openshift-.*,^logging$,^default$,^openshift$,^ops-health-monitoring$,^ops-project-operation-check$,^management-infra$",
 		},
 	}, nil
 }


### PR DESCRIPTION
Tried deploying to OSD 3.11 cluster w/o OLM and fixed these:
- Role 'dedicated-admin-operator' now specifies namespace
- Deployment references quay.io/openshift-sre
- Makefile pushes 'latest' tag
- Makefile target 'push' no longer depends on 'build' target
- Added additional blacklist namespaces based on current OSD 3.11 configuration