### PR TITLE
Update yq image

### DIFF
--- a/functions.mk
+++ b/functions.mk
@@ -18,7 +18,7 @@ define create_push_catalog_image
 	mkdir -p bundles-$(1)/$(OPERATOR_NAME) ;\
 	removed_versions="" ;\
 	if [[ "$$(echo $(4) | tr [:upper:] [:lower:])" == "true" ]]; then \
-		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | docker run --rm -i mikefarah/yq:2.2.0 yq r - '.services[]|select(.name="hive").hash') ;\
+		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | docker run --rm -i evns/yq -r '.services[]|select(.name="dedicated-admin-operator").hash' ;\
 		delete=false ;\
 		for bundle_path in $$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do \
 			if [[ "$${delete}" == false ]]; then \


### PR DESCRIPTION
This PR fixes the yq image to match what Hive is using in their build scripts and updates the select to use the correct name.