### PR TITLE
Enable dedicated-admins to view Cluster Monitoring stack 

### DIFF
--- a/manifests/35-dedicated-admin-cluster-monitoring-view.ClusterRoleBinding.yaml
+++ b/manifests/35-dedicated-admin-cluster-monitoring-view.ClusterRoleBinding.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dedicated-admin-cluster-monitoring-view
+roleRef:
+  kind: ClusterRole
+  name:  cluster-monitoring-view
+subjects:
+- kind: Group
+  name: dedicated-admins


### PR DESCRIPTION
In order to get read access to the cluster monitoring stack, the dedicated-admins group gets a ClusterRoleBinding to the ClusterRole cluster-monitoring-view. 