### PR TITLE
SREP-1686 OLM bug when version hash starts with zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ OLM currently cannot support creation of arbitrary resources when an operator is
 - `ServiceMonitor` - for prometheus to scrape metrics from the `Service`
 - `ClusterRoleBinding` - for `dedicated-admins-cluster` `ClusterRole` to `dedicated-admins` `Group`
 
+
 Note the creation of `ClusterRoleBindings` is possible via a `ClusterServiceVersion` CR, used to deploy an operator.  But it can only have a `ServiceAccount` as the subject.  At this time you cannot create a `ClusterRoleBinding` to other subjects in a `ClusterServiceVersion`.
+
 
 Create resources in the operator's `Namespace`


### PR DESCRIPTION
workaround bump commit

bz: https://bugzilla.redhat.com/show_bug.cgi?id=1724742