### PR TITLE
Dedicated-admins can manage logging

### DIFF
--- a/manifests/04-openshift-logging.Namespace.yaml
+++ b/manifests/04-openshift-logging.Namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    openshift.io/node-selector: "" 
+  labels:
+    openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"

--- a/manifests/05-dedicated-admins-logging.ClusterRole.yaml
+++ b/manifests/05-dedicated-admins-logging.ClusterRole.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dedicated-admins-logging
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - pods/log
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - clusterloggings
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/manifests/05-dedicated-admins-logging.RoleBinding.yaml
+++ b/manifests/05-dedicated-admins-logging.RoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-logging
+  namespace: openshift-logging
+subjects:
+- kind: Group
+  name: dedicated-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-logging


### PR DESCRIPTION
Allow customer to:
* view, create, edit, delete ClusterLogging CR in openshift-logging NS
* view pods in openshift-logging NS
* view pod logs in openshift-logging NS

This allows customers to opt-in (and then opt-out) to logging by managing the ClusterLogging CR

Note this duplicates creation of the openshift-logging namespace to ensure the namespace exists before rolebinding is created.  It's the same YAML as included in managed-cluster-config repo.