### PR TITLE
Move blacklist regex to config and clean it up

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,4 +18,5 @@ const (
 	OperatorConfigMapName string = "dedicated-admin-operator-config"
 	OperatorName          string = "dedicated-admin-operator"
 	OperatorNamespace     string = "openshift-dedicated-admin"
+	BlacklistRegex        string = "^kube-.*,^openshift.*,^default$"
 )

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -121,7 +121,7 @@ func makeConfig() *corev1.ConfigMap {
 			Namespace: operatorconfig.OperatorNamespace,
 		},
 		Data: map[string]string{
-			"project_blacklist": "^kube-.*,^openshift-.*,^logging$,^default$,^openshift$",
+			"project_blacklist": operatorconfig.BlacklistRegex,
 		},
 	}
 }

--- a/pkg/controller/rolebinding/rolebinding_controller_test.go
+++ b/pkg/controller/rolebinding/rolebinding_controller_test.go
@@ -173,7 +173,7 @@ func makeConfig() *corev1.ConfigMap {
 			Namespace: operatorconfig.OperatorNamespace,
 		},
 		Data: map[string]string{
-			"project_blacklist": "^kube-.*,^openshift-.*,^logging$,^default$,^openshift$",
+			"project_blacklist": operatorconfig.BlacklistRegex,
 		},
 	}
 }

--- a/pkg/dedicatedadmin/dedicatedadmin.go
+++ b/pkg/dedicatedadmin/dedicatedadmin.go
@@ -51,7 +51,7 @@ func GetOperatorConfig(ctx context.Context, k8sClient client.Client) (*corev1.Co
 		},
 		// Always update the PrometheusRule when updating this regexp, reflecting the same changes on the expr for the alert rule
 		Data: map[string]string{
-			"project_blacklist": "^kube-.*,^openshift-.*,^logging$,^default$,^openshift$,^ops-health-monitoring$,^ops-project-operation-check$,^management-infra$",
+			"project_blacklist": operatorconfig.BlacklistRegex,
 		},
 	}, nil
 }


### PR DESCRIPTION
It was defined in three places inconsistently.  Also had been initially setup with OSD v3 namespaces in mind as well.  Removed the inconsistency, simplified the regex where possible, and dropped the OSD v3 specific patterns.