### PR TITLE
Fixing rbac for logging and monitoring

### DIFF
--- a/build/generate-operator-bundle.py
+++ b/build/generate-operator-bundle.py
@@ -90,6 +90,9 @@ if __name__ == '__main__':
             with open(file_path) as stream:
                 yaml_file = yaml.safe_load_all(stream)
                 for obj in yaml_file:
+                    # skip if it's not deployed in the operator's namespace (TODO automate building the template!!!)
+                    if 'namespace' in obj['metadata'] and obj['metadata']['namespace'] != operator_namespace:
+                        continue
                     if obj['kind'] == 'ClusterRole' and any(obj['metadata']['name'] in cr for cr in clusterrole_names_csv):
                         print('Adding ClusterRole to CSV: {}'.format(file_path))
                         csv['spec']['install']['spec']['clusterPermissions'].append(

--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -87,3 +87,91 @@ objects:
               message: "The number of projects blacklisted by dedicated-admin-operator does not match the expected regular expression"
             labels:
               severity: critical
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-logging
+        annotations:
+          openshift.io/node-selector: "" 
+        labels:
+          openshift.io/cluster-logging: "true"
+          openshift.io/cluster-monitoring: "true"
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-logging
+        namespace: openshift-logging
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - namespaces
+        - pods
+        - pods/log
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - logging.openshift.io
+        resources:
+        - clusterloggings
+        verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-logging
+        namespace: openshift-logging
+      subjects:
+      - kind: Group
+        name: dedicated-admins
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-logging
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-cluster-monitoring-view
+        namespace: openshift-monitoring
+      roleRef:
+        kind: ClusterRole
+        name:  cluster-monitoring-view
+      subjects:
+      - kind: Group
+        name: dedicated-admins
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-cluster-monitoring-routes
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - route.openshift.io
+        resources: 
+        - routes
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-cluster-monitoring-routes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-cluster-monitoring-routes
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins

--- a/manifests/05-dedicated-admins-logging.Role.yaml
+++ b/manifests/05-dedicated-admins-logging.Role.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: dedicated-admins-logging
+  namespace: openshift-logging
 rules:
 - apiGroups:
   - ""

--- a/manifests/06-dedicated-admins-logging.RoleBinding.yaml
+++ b/manifests/06-dedicated-admins-logging.RoleBinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: dedicated-admins-logging
@@ -8,5 +8,5 @@ subjects:
   name: dedicated-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: dedicated-admins-logging

--- a/manifests/35-dedicated-admins-cluster-monitoring-view.RoleBinding.yaml
+++ b/manifests/35-dedicated-admins-cluster-monitoring-view.RoleBinding.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: dedicated-admin-cluster-monitoring-view
+  name: dedicated-admins-cluster-monitoring-view
+  namespace: openshift-monitoring
 roleRef:
   kind: ClusterRole
   name:  cluster-monitoring-view

--- a/manifests/36-dedicated-admins-cluster-monitoring-routes.Role.yaml
+++ b/manifests/36-dedicated-admins-cluster-monitoring-routes.Role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-cluster-monitoring-routes
+  namespace: openshift-monitoring
+rules:
+- apiGroups:
+  - route.openshift.io
+  resources: 
+  - routes
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/37-dedicated-admins-cluster-monitoring-routes.RoleBinding.yaml
+++ b/manifests/37-dedicated-admins-cluster-monitoring-routes.RoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-cluster-monitoring-routes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-cluster-monitoring-routes
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins


### PR DESCRIPTION
- Grant monitoring access only in openshift-monitoring
- Remove all role and rolebindings from CatalogSource image and put in template

Note the work to generate the template file is not in scope of this PR. See https://github.com/openshift/dedicated-admin-operator/issues/57