### PR TITLE
Added CatalogSource and Subscription back into the template

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Template
 parameters:
+- name: REGISTRY_IMG
+  required: true
+- name: CHANNEL
+  required: true
 - name: IMAGE_TAG
   required: true
 - name: REPO_NAME
@@ -427,3 +431,29 @@ objects:
                 does not match the expected regular expression
             labels:
               severity: critical
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        labels:
+          opsrc-datastore: 'true'
+          opsrc-provider: redhat
+        name: dedicated-admin-operator-registry
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
+        displayName: Dedicated Admin Operator
+        icon:
+          base64data: ''
+          mediatype: ''
+        publisher: Red Hat
+        sourceType: grpc
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: dedicated-admin-operator
+        namespace: openshift-dedicated-admin
+      spec:
+        channel: ${CHANNEL}
+        name: dedicated-admin-operator
+        source: dedicated-admin-operator-registry
+        sourceNamespace: openshift-operator-lifecycle-manager

--- a/manifests/80-dedicated-admin-operator-registry.CatalogSource.yaml
+++ b/manifests/80-dedicated-admin-operator-registry.CatalogSource.yaml
@@ -1,0 +1,16 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  labels:
+    opsrc-datastore: "true"
+    opsrc-provider: redhat
+  name: dedicated-admin-operator-registry
+  namespace: openshift-operator-lifecycle-manager
+spec:
+  image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
+  displayName: Dedicated Admin Operator
+  icon:
+    base64data: ""
+    mediatype: ""
+  publisher: Red Hat
+  sourceType: grpc

--- a/manifests/81-dedicated-admin-operator.Subscription.yaml
+++ b/manifests/81-dedicated-admin-operator.Subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: dedicated-admin-operator
+  namespace: openshift-dedicated-admin
+spec:
+  channel: ${CHANNEL}
+  name: dedicated-admin-operator
+  source: dedicated-admin-operator-registry
+  sourceNamespace: openshift-operator-lifecycle-manager

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Template
 parameters:
+- name: REGISTRY_IMG
+  required: true
+- name: CHANNEL
+  required: true
 - name: IMAGE_TAG
   required: true
 - name: REPO_NAME


### PR DESCRIPTION
Put them into `manifests/` with the params.  This means they can't be applied as-is on a cluster from that directory.

NOTE this only shows up when trying to apply the template with `oc process` which is in another repo.  Can't think of a good way to check this as it's a private repo, not available to the PR check run against github at this time.