### PR TITLE
Add additional configmap verbs to operator

### DIFF
--- a/manifests/02-dedicated-admin-operator.Role.yaml
+++ b/manifests/02-dedicated-admin-operator.Role.yaml
@@ -12,3 +12,9 @@ rules:
   - configmaps
   verbs:
   - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
```
User \"system:serviceaccount:openshift-dedicated-admin:dedicated-admin-operator\" cannot create resource \"configmaps\" in API group \"\" in the namespace \"openshift-dedicated-admin\""
```

Operator needs to create configmaps in it's own namespace. This should be safe to give it all the default verbs because it's scoped to it's own NS.