### PR TITLE
Dedicated-admins can install operators from OperatorHub only

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -191,6 +191,21 @@ objects:
         - subjectaccessreviews
         verbs:
         - create
+      - apiGroups:
+        - operators.coreos.com
+        - packages.operators.coreos.com
+        resources:
+        - '*'
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - '*'
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -392,17 +407,62 @@ objects:
         - update
         - watch
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-openshift-operators
+        namespace: openshift-operators
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - subscriptions
+        - clusterserviceversions
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        name: dedicated-admins-logging
-        namespace: openshift-logging
+        name: dedicated-admins-openshift-operators
+        namespace: openshift-operators
       subjects:
       - kind: Group
         name: dedicated-admins
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
-        name: dedicated-admins-logging
+        name: dedicated-admins-openshift-operators
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-openshift-marketplace
+        namespace: openshift-marketplace
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsourceconfigs
+        verbs:
+        - '*'
+      - apiGroups:
+        - '*'
+        resources:
+        - packagemanifests
+        verbs:
+        - list
+        - get
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-marketplace
+        namespace: openshift-marketplace
+      subjects:
+      - kind: Group
+        name: dedicated-admins
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshift-marketplace
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
+++ b/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
@@ -168,3 +168,20 @@ rules:
   verbs:
   - create
 ### END - customer can create verify tokens and access
+### BEGIN - customer can view OperatorHub in console
+- apiGroups:
+  - operators.coreos.com
+  - packages.operators.coreos.com
+  resources:
+  - "*"
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - '*' # using package.opeartors.coreos.com does not work
+  resources:
+  - packagemanifests
+  verbs:
+  - list
+### END - customer can view OperatorHub in console

--- a/manifests/07-dedicated-admins-operators.Role.yaml
+++ b/manifests/07-dedicated-admins-operators.Role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-openshift-operators
+  namespace: openshift-operators
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  - clusterserviceversions
+  verbs:
+  - "*"

--- a/manifests/07-dedicated-admins-operators.RoleBinding.yaml
+++ b/manifests/07-dedicated-admins-operators.RoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-openshift-operators
+  namespace: openshift-operators
+subjects:
+- kind: Group
+  name: dedicated-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-openshift-operators

--- a/manifests/08-dedicated-admins-marketplace.Role.yaml
+++ b/manifests/08-dedicated-admins-marketplace.Role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-openshift-marketplace
+  namespace: openshift-marketplace
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsourceconfigs
+  verbs:
+  - "*"
+- apiGroups:
+  - "*"
+  resources:
+  - packagemanifests
+  verbs:
+  - list
+  - get
+  - watch

--- a/manifests/08-dedicated-admins-marketplace.RoleBinding.yaml
+++ b/manifests/08-dedicated-admins-marketplace.RoleBinding.yaml
@@ -1,12 +1,13 @@
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: dedicated-admins-logging
-  namespace: openshift-logging
+  name: dedicated-admins-openshift-marketplace
+  namespace: openshift-marketplace
 subjects:
 - kind: Group
   name: dedicated-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: dedicated-admins-logging
+  name: dedicated-admins-openshift-marketplace


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1370

This assumes the operators displayed are what we want installed.  Those will be managed elsewhere.

A few things to note about this change:
- packagemanifests doesn't have an apiGroup that is reported by the api, so it's just going to be '*'
- we have to grant delete on catalogsourceconfig else deleting operators leaves things in a state where install can't happen, specifically deleting the last operator in an operatorsource
