### PR TITLE
Update RBAC so customer can install logging operator

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -388,7 +388,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: dedicated-admins-logging
+        name: dedicated-admins-openshift-logging
         namespace: openshift-logging
       rules:
       - apiGroups:
@@ -414,6 +414,25 @@ objects:
         - patch
         - update
         - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - subscriptions
+        - clusterserviceversions
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-logging
+        namespace: openshift-logging
+      subjects:
+      - kind: Group
+        name: dedicated-admins
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshift-logging
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/manifests/05-dedicated-admins-logging.Role.yaml
+++ b/manifests/05-dedicated-admins-logging.Role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: dedicated-admins-logging
+  name: dedicated-admins-openshift-logging
   namespace: openshift-logging
 rules:
 - apiGroups:
@@ -27,3 +27,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  - clusterserviceversions
+  verbs:
+  - "*"

--- a/manifests/05-dedicated-admins-logging.RoleBinding.yaml
+++ b/manifests/05-dedicated-admins-logging.RoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-openshift-logging
+  namespace: openshift-logging
+subjects:
+- kind: Group
+  name: dedicated-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-openshift-logging


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1897

It's one operator we allow installing to a non-default namespace: openshift-logging.
With the recent change to put installation of the operator on the customer's opt-in to logging we need to add allowing installation to the openshift-logging namespace.