### PR TITLE
Add RBAC so customer can manage CRs for CRDs installed by curated ope…

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -212,6 +212,29 @@ objects:
         - packagemanifests
         verbs:
         - list
+      - apiGroups:
+        - certificates.certmanager.k8s.io
+        - issuers.certmanager.k8s.io
+        - clusterissuers.certmanager.k8s.io
+        - orders.certmanager.k8s.io
+        - challenges.certmanager.k8s.io
+        - anchoreengines.anchore.com
+        - atlasmaps.atlasmap.io
+        - builds.camel.apache.org
+        - camelcatalogs.camel.apache.org
+        - integrations.camel.apache.org
+        - integrationcontexts.camel.apache.org
+        - integrationplatforms.camel.apache.org
+        - couchbaseclusters.couchbase.com
+        - openliberties.openliberty.io
+        - opsmxspinnakeroperators.charts.helm.k8s.io
+        - seldondeployments.machinelearning.seldon.io
+        - spinnakeroperators.charts.helm.k8s.io
+        - twistlockconsoles.charts.helm.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - '*'
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
+++ b/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
@@ -185,3 +185,38 @@ rules:
   verbs:
   - list
 ### END - customer can view OperatorHub in console
+### START - customer can managed CRs for curated operators
+- apiGroups:
+# AMQ Certificate Manager Operator
+  - certificates.certmanager.k8s.io
+  - issuers.certmanager.k8s.io
+  - clusterissuers.certmanager.k8s.io
+  - orders.certmanager.k8s.io
+  - challenges.certmanager.k8s.io
+# Anchore Engine Operator
+  - anchoreengines.anchore.com
+# AtlasMap Operator
+  - atlasmaps.atlasmap.io
+# Camel K Operator
+  - builds.camel.apache.org
+  - camelcatalogs.camel.apache.org
+  - integrations.camel.apache.org
+  - integrationcontexts.camel.apache.org
+  - integrationplatforms.camel.apache.org
+# Couchbase Operator
+  - couchbaseclusters.couchbase.com
+# Open Liberty Operator
+  - openliberties.openliberty.io
+# Opsmx Spinnaker Operator
+  - opsmxspinnakeroperators.charts.helm.k8s.io
+# Seldon Operator
+  - seldondeployments.machinelearning.seldon.io
+# Spinnaker Operator
+  - spinnakeroperators.charts.helm.k8s.io
+# Twistlock Console Operator
+  - twistlockconsoles.charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+### END


### PR DESCRIPTION
…rators

https://jira.coreos.com/browse/SREP-1898

Customers can install the operator but can't manage them without ability to manage the CR instances provided by the operator.