### PR TITLE
Customer can get routes in all namespaces

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -185,6 +185,7 @@ objects:
         - routes
         verbs:
         - list
+        - get
       - apiGroups:
         - authentication.k8s.io
         resources:

--- a/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
+++ b/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
@@ -153,6 +153,7 @@ rules:
   - routes
   verbs:
   - list
+  - get # https://jira.coreos.com/browse/SREP-1945
 ### END - customer can see project status (nice UX from use monitoring web applications)
 ### BEGIN - customer can create verify tokens and access
 - apiGroups:


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1945

To make it easier and cleaner to get host from spec of specific routes in core namespaces.