### PR TITLE
Exclude openshift-logging namespace from cluster quota

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -407,6 +407,8 @@ objects:
         annotations:
           openshift.io/node-selector: ''
         labels:
+          managed.openshift.io/service-lb-quota-exempt: 'true'
+          managed.openshift.io/storage-pv-quota-exempt: 'true'
           openshift.io/cluster-logging: 'true'
           openshift.io/cluster-monitoring: 'true'
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/04-openshift-logging.Namespace.yaml
+++ b/manifests/04-openshift-logging.Namespace.yaml
@@ -3,7 +3,9 @@ kind: Namespace
 metadata:
   name: openshift-logging
   annotations:
-    openshift.io/node-selector: "" 
+    openshift.io/node-selector: ""
   labels:
+    managed.openshift.io/service-lb-quota-exempt: "true"
+    managed.openshift.io/storage-pv-quota-exempt: "true"
     openshift.io/cluster-logging: "true"
     openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1960

It's managed fine in `managed-cluster-config` but it's also created here and it bit us.