### PR TITLE
Add static namespaces for v3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,5 +18,5 @@ const (
 	OperatorConfigMapName string = "dedicated-admin-operator-config"
 	OperatorName          string = "dedicated-admin-operator"
 	OperatorNamespace     string = "openshift-dedicated-admin"
-	BlacklistRegex        string = "^kube-.*,^openshift.*,^default$"
+	BlacklistRegex        string = "^kube-.*,^openshift.*,^ops-health-monitoring$,^management-infra$,^default$"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -18,5 +18,5 @@ const (
 	OperatorConfigMapName string = "dedicated-admin-operator-config"
 	OperatorName          string = "dedicated-admin-operator"
 	OperatorNamespace     string = "openshift-dedicated-admin"
-	BlacklistRegex        string = "^kube-.*,^openshift.*,^ops-health-monitoring$,^management-infra$,^default$"
+	BlacklistRegex        string = "^kube-.*,^openshift.*,^ops-health-monitoring$,^management-infra$,^default$,^logging$"
 )


### PR DESCRIPTION
This will allow us to backport the operator to OSD v3,
since v3 has these namespaces blacklisted.

https://jira.coreos.com/browse/SREP-1743