### PR TITLE
:bug: Compare version to correct thing

### DIFF
--- a/functions.mk
+++ b/functions.mk
@@ -41,7 +41,7 @@ define create_push_catalog_image
 	fi ;\
 	python $(7) bundles-$(1)/$(OPERATOR_NAME) $(OPERATOR_NAME) $(OPERATOR_NAMESPACE) $(OPERATOR_VERSION) $(OPERATOR_IMAGE_URI) $(1) false $$previous_version ;\
 	new_version=$$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1 | cut -d / -f 3-) ;\
-	if [[ $$new_version == $$previous_version ]]; then \
+	if [[ $(OPERATOR_NAME).v$${new_version} == $$previous_version ]]; then \
 		echo "Already built this, so no need to continue" ;\
 		exit 0 ;\
 	fi ;\


### PR DESCRIPTION
On line 36, we get a value looking something like this `0.1.166-1e758c1` and then immediately check if it exists, if it does, we reset it to `$(OPERATOR_NAME).$$version`, in this case `dedicated-admin-operator.v0.1.166-1e758c1`. Then, we build the new bundle and on line 43 detect what that bundle was.

Line 43 gives us something looking like `0.1.166-1e758c1`. On line 44 we try to check if this is a re-build, and if it is, we should bail out. But, we're comparing `dedicated-admin-operator.v0.1.166-1e758c1 to 0.1.166-1e758c1`.

This change, on line 44, makes sure to compare like to like.