### PR TITLE
SREP-2178 Added perms for dedicated-admins to manage prometheus objects

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -348,6 +348,16 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - prometheus
+        - alertmanager
+        - prometheusrules
+        - servicemonitors
+        - podmonitors
+        verbs:
+        - '*'
     - apiVersion: v1
       kind: Namespace
       metadata:

--- a/manifests/00-dedicated-admins-project.ClusterRole.yaml
+++ b/manifests/00-dedicated-admins-project.ClusterRole.yaml
@@ -101,3 +101,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - prometheus
+  - alertmanager
+  - prometheusrules
+  - servicemonitors
+  - podmonitors
+  verbs:
+  - "*"


### PR DESCRIPTION
Since those permissions have been removed from the `admin` ClusterRole in the product between 4.1.18 and 4.1.20 upgrades, I'm adding them to the `dedicated-admin-project` ClusterRole, that gets assigned to each customer NS by the `dedicated-admin-operator`

cc @jmelis @jfchevrette   