### PR TITLE
SREP-2178 turn resources to plural in Role def

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -351,8 +351,8 @@ objects:
       - apiGroups:
         - monitoring.coreos.com
         resources:
-        - prometheus
-        - alertmanager
+        - prometheuses
+        - alertmanagers
         - prometheusrules
         - servicemonitors
         - podmonitors

--- a/manifests/00-dedicated-admins-project.ClusterRole.yaml
+++ b/manifests/00-dedicated-admins-project.ClusterRole.yaml
@@ -104,8 +104,8 @@ rules:
 - apiGroups:
   - "monitoring.coreos.com"
   resources:
-  - prometheus
-  - alertmanager
+  - prometheuses
+  - alertmanagers
   - prometheusrules
   - servicemonitors
   - podmonitors


### PR DESCRIPTION
In `dedicated-admin-project` Role definition:

`prometheus` -> `prometheuses`
`alertmanager` -> `alertmanagers`