### PR TITLE
SREP-2178 Permission parity with v3, add GET, WATCH Pod, ReplicationControllers, Services perm to dedicated-admins

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -174,6 +174,8 @@ objects:
         - services
         verbs:
         - list
+        - get
+        - watch
       - apiGroups:
         - project.openshift.io
         resources:

--- a/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
+++ b/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
@@ -142,6 +142,8 @@ rules:
   - services
   verbs:
   - list
+  - get
+  - watch
 - apiGroups:
   - project.openshift.io
   resources:


### PR DESCRIPTION
Adding `GET, WATCH` Pod, ReplicationController, Service permissions to dedicated-admins, as we have in OSD v3