### PR TITLE
Blacklist namespaces starting with sre-app-check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,5 +18,5 @@ const (
 	OperatorConfigMapName string = "dedicated-admin-operator-config"
 	OperatorName          string = "dedicated-admin-operator"
 	OperatorNamespace     string = "openshift-dedicated-admin"
-	BlacklistRegex        string = "^kube-.*,^openshift.*,^ops-health-monitoring$,^management-infra$,^default$,^logging$,^sre-app-check$"
+	BlacklistRegex        string = "^kube-.*,^openshift.*,^ops-health-monitoring$,^management-infra$,^default$,^logging$,^sre-app-check.*"
 )


### PR DESCRIPTION
The app-create check has been modified to use more than one namespace,
so we need to blacklist all of them.