### PR TITLE
SREP-2178 Give permission to dedicated-admins to manage Strimzi Kafka CRDs

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -360,6 +360,18 @@ objects:
         - podmonitors
         verbs:
         - '*'
+      - apiGroups:
+        - kafka.strimzi.io
+        resources:
+        - '*'
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
     - apiVersion: v1
       kind: Namespace
       metadata:

--- a/manifests/00-dedicated-admins-project.ClusterRole.yaml
+++ b/manifests/00-dedicated-admins-project.ClusterRole.yaml
@@ -111,3 +111,15 @@ rules:
   - podmonitors
   verbs:
   - "*"
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - "*"
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
Give permission to dedicated-admins to manage strimzi kafka operator CRDs.

apiGroup: kafka.strimzi.io