### PR TITLE
permissions for OSD-2545

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -247,6 +247,12 @@ objects:
         - list
         - get
         - watch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routers/metrics
+        verbs:
+        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
+++ b/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
@@ -234,3 +234,11 @@ rules:
   - get
   - watch
 ### END
+### BEGIN - customer can access openshift haproxy router metrics
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routers/metrics
+  verbs:
+  - get
+### END - customer can access openshift haproxy router metrics


### PR DESCRIPTION
in order to allow dedicated admins to scrape router metrics, we need some more permissions