### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,20 @@
 reviewers:
 - jewzaam
 - rogbas
+- bmeng
+- mrbarge
+- ravitri
+- anjoshi24
+- a7vicky
+- T0MASD
+
 approvers:
 - jewzaam
 - rogbas
+- mrbarge
+- bmeng
+- ravitri
+
 maintainers:
+- mrbarge
 - rogbas


### PR DESCRIPTION
Per the recent assignment of functional team ownership / SDE-1417, OWNERS is proposed to be updated to a new set of reviewers and approvers.
